### PR TITLE
Fixes the extension's behavior that chrome returns maxLength -1 if it…

### DIFF
--- a/js/gInfinity.js
+++ b/js/gInfinity.js
@@ -168,7 +168,7 @@ $(document).ready(function () {
             document.onkeyup = function (event) {
                 if ($.inArray(event.keyCode, codes) == -1) {
                     if ($(event.target).is('input')) {
-                        if (event.target.maxLength) {
+                        if (event.target.maxLength > 0) {
                             if (event.target.value.length >= event.target.maxLength) {
                                 var index = (getIndex(event.target) + 1);
                                 var mod = index % event.target.form.length;


### PR DESCRIPTION
… is not set.. Fixes #1.

Fixes the extension's behavior that chrome returns maxLength -1 if it is not set. So we check if event.target.maxLength > 0. event.target.maxLength is a number and not a complex element, so the if(event.target.maxLength) works directly on the number.
