### PR TITLE
adds web_accessible_resources section to the manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name" : "gInfinity",
-  "version" : "2.4.1",
+  "version" : "2.4.2",
   "manifest_version" : 2,
   "description" : "Infinite scroll for Google search results and a lot of other improvements to your browser experience.",
   "background" : {
@@ -21,5 +21,10 @@
     "16" : "images/infen_logo_16x16.png",
     "48" : "images/infen_logo_48x48.png",
     "128" : "images/infen_logo_128x128.png"
-  }
+  },
+   "web_accessible_resources": [
+    "images/*",
+    "js/*.js",
+    "lib/*"
+  ]
 }


### PR DESCRIPTION
Hello Thomas, 

I've tested your extension on a Chrome 58 and found that the console showed this error message: 

Denying load of chrome-extension://dgomfdmdnjbnfhodggijhpbmkgfabcmn/images/progress.gif. Resources must be listed in the web_accessible_resources manifest key in order to be loaded by pages outside the extension.

I've cloned the repo and added  the "web_accessible_resources" section in the manifest.json file as it is explained in https://developer.chrome.com/extensions/manifest/web_accessible_resources file,  so the error does not appear anymore.  

I've also incremented the version number to 2.4.2.  

Please check these changes and thanks for this extension. 

